### PR TITLE
Click: Single vs Double quote quirkyness on Windows platform.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,13 @@ python3 -m wiz
 ```
 OR
 ```
-python3 -m wiz -a 'Mike Yusko' -n my_first_project -lt MIT
+python3 -m wiz -a "Mike Yusko" -n my_first_project -lt MIT
 ```
 Where **-a** is an author name, **-n** name of project, and **-lt** type of license.
 And wizi will create for you tree of project, and added most used files.
+
+> NOTE: If you are on Windows, enclose your name in double-quotes if you are entering
+your first and last name.
 
 Example of tree
 ===============


### PR DESCRIPTION
Discovered that if single quotes are used while entering your first and last name for the author, click will try and split the string on the empty space. To avoid that double-quotes must be used. I've updated the README.md file to warn users.